### PR TITLE
Support symbols as event names

### DIFF
--- a/chai-events.js
+++ b/chai-events.js
@@ -68,7 +68,7 @@ function plugin(chai, utils) {
         obj.on(name, function() {
           if(done) { return; }
           done = true;
-          assert(false, "expected #{this} to not emit "+name+".");
+          assert(false, "expected #{this} to not emit "+name.toString()+".");
           resolve();
         });
         setTimeout(function() {
@@ -90,7 +90,7 @@ function plugin(chai, utils) {
         setTimeout(function() {
           if(done) { return; }
           done = true;
-          assert(false, "expected #{this} to emit "+name+".");
+          assert(false, "expected #{this} to emit "+name.toString()+".");
           resolve();
         }, timeout);
       });

--- a/chai-events.js
+++ b/chai-events.js
@@ -50,7 +50,10 @@ function plugin(chai, utils) {
   Assertion.addMethod("emit", function(name, args) {
     new Assertion(this._obj).to.be.an.emitter;
 
-    new Assertion(name).to.be.a("string");
+    new Assertion(name).to.satisfy(function(_name) {
+        return typeof _name === 'string' || typeof _name === 'symbol';
+    });
+
     var obj = this._obj;
     var _this = this;
     var assert = function() {

--- a/test/test-emit.js
+++ b/test/test-emit.js
@@ -24,6 +24,12 @@ describe("x.should.emit", function() {
     emitter.emit("test", true);
   });
 
+  it("should handle symbols as events", function(done) {
+    const event = Symbol('test');
+    emitter.should.emit(event).then(done);
+    emitter.emit(event, true);
+  });
+
   it("should fail if the event isn't sent", function() {
     (function() {
       emitter.should.emit("test");


### PR DESCRIPTION
ES6 allows symbols to be used for event names, so it should be supported